### PR TITLE
feat(metric_reporter): add FxA integration tests

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -15,6 +15,11 @@ pipelines = [
         "workflows": {
           "nightly": [
             "Unit Test (nightly)",
+            "Integration Test - Frontends (nightly)",
+            "Integration Test - Libraries (nightly)",
+            "Integration Test - Servers (nightly)",
+            "Integration Test - Servers - Auth (nightly)",
+            "Integration Test - Servers - Auth V2 (nightly)",
             "Functional Tests - Playwright (nightly)"
           ],
           "stage_smoke_tests": [

--- a/scripts/metric_reporter/junit_xml_parser.py
+++ b/scripts/metric_reporter/junit_xml_parser.py
@@ -31,7 +31,7 @@ class JUnitXmlSkipped(BaseModel):
 class JUnitXmlFailure(BaseModel):
     """Represents a failure of a test case."""
 
-    message: str
+    message: str | None = None
     type: str | None = None
     text: str | None = None
 

--- a/tests/metric_reporter/test_data/xml_samples_jest/1/jest_failure.xml
+++ b/tests/metric_reporter/test_data/xml_samples_jest/1/jest_failure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="1" failures="1" errors="0" time="0.017">
+  <testsuite name="useCheckboxStateResult" errors="0" failures="1" skipped="0" timestamp="2024-07-13T00:21:53" time="0.017" tests="1">
+    <testcase classname="useInfoBoxMessage coupon type is &quot;repeating&quot; plan interval equal to coupon duration" name="useInfoBoxMessage coupon type is &quot;repeating&quot; plan interval equal to coupon duration" time="0.017">
+      <failure>Error: expect(element).not.toBeInTheDocument()</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/metric_reporter/test_junit_xml_parser.py
+++ b/tests/metric_reporter/test_junit_xml_parser.py
@@ -28,6 +28,49 @@ EXPECTED_JEST = [
                 id=None,
                 name="jest tests",
                 tests=1,
+                failures=1,
+                skipped=None,
+                errors=0,
+                time=0.017,
+                timestamp=None,
+                test_suites=[
+                    JUnitXmlTestSuite(
+                        name="useCheckboxStateResult",
+                        timestamp="2024-07-13T00:21:53",
+                        hostname=None,
+                        tests=1,
+                        failures=1,
+                        skipped=0,
+                        time=0.017,
+                        errors=0,
+                        test_cases=[
+                            JUnitXmlTestCase(
+                                name=(
+                                    'useInfoBoxMessage coupon type is "repeating" plan interval '
+                                    "equal to coupon duration"
+                                ),
+                                classname=(
+                                    'useInfoBoxMessage coupon type is "repeating" plan interval '
+                                    "equal to coupon duration"
+                                ),
+                                time=0.017,
+                                properties=None,
+                                skipped=None,
+                                failure=JUnitXmlFailure(
+                                    message=None,
+                                    type=None,
+                                    text="Error: expect(element).not.toBeInTheDocument()",
+                                ),
+                                system_out=None,
+                            )
+                        ],
+                    )
+                ],
+            ),
+            JUnitXmlTestSuites(
+                id=None,
+                name="jest tests",
+                tests=1,
                 failures=0,
                 skipped=None,
                 errors=0,


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

- adds FxA unit tests to scraping and reporting scripts
- updates SuiteReporter to handle Jest JUnit XML test failure

**NOTES**
- The `Integration Test - Servers - Auth V2 (nightly)` tests don't report test results to CircleCI or upload JUnit XMLs at this time. A request to add this information has been made on the FxA side ([FXA-8953](https://mozilla-hub.atlassian.net/browse/FXA-8953), [PR](https://github.com/mozilla/fxa/pull/17375/files))

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [x] AI tools were used in generating this pull request

## Issues

Closes: [ECTEEN-113](https://mozilla-hub.atlassian.net/browse/ECTEEN-113)
