### PR TITLE
fix(circleci_scraper): failure due to missing job number

### DIFF
--- a/scripts/circleci_scraper/scraper.py
+++ b/scripts/circleci_scraper/scraper.py
@@ -171,6 +171,14 @@ class CircleCIScraper:
             jobs: JobGroup = self._client.get_jobs(workflow.id, next_page_token)
             for job in jobs.items:
                 if job.name in job_names:
+                    if not job.job_number:
+                        # This happens when workflows are cancelled before a number is assigned
+                        # to the test job
+                        logging.warning(
+                            f"Skipping data for workflow {workflow.id} because the job number is "
+                            f"missing for {organization}>{repository}>{workflow.name}>{job.name}"
+                        )
+                        continue
                     self.export_test_metadata_by_job(organization, repository, workflow.name, job)
                     self.export_test_artifacts_by_job(organization, repository, workflow.name, job)
             next_page_token = jobs.next_page_token


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

Added an if statement to handle a previously non-encountered situation where a job doesn't have a number. Theory is that the workflow was cancelled before the job was assigned a number and ran. There is no test data to scrape in this case.

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes #[ECTEEN-115](https://mozilla-hub.atlassian.net/browse/ECTEEN-115)

