### PR TITLE
chore(docs): publish mdbook straight to deployment env

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Publish Docs
+
+on:
+  workflow_dispatch: # allow manual runs
+  push:
+    branches:
+      - main
+    paths: # avoid unnecessary builds
+      - docs/**
+      - book.toml
+      - .github/workflows/docs.yml
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false # skip any intermediate builds but let finish
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.4.40
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: cargo install --version ${MDBOOK_VERSION} mdbook
+      - id: pages
+        uses: actions/configure-pages@v5
+      - run: mdbook build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./book
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

This builds the mdbook from _main_ anytime a push changes `/docs/**` or `book.toml` and stores that as an artifact, the artifact is then deployed to the _github-pages_ environment directly without writing anything to another branch et al.

Once you finish #7 and get it merged, you need to change GitHub Pages _publishing source_ in repo settings from branch deploy to GitHub Actions (also making sure any branch protections on the environment include "main", not just "gh-pages"), and this workflow will do the rest.

When you're happy with the setup you can then remove the `gh-pages` branch completely as it won't be used anymore for publishing.

- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] ~AI tools were used in generating this pull request~