### PR TITLE
feat(circleci_scraper): add scraping of coverage reports

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,7 +1,8 @@
 [common]
 test_result_dir = raw_data
 test_metadata_dir = circle_ci
-test_artifact_dir = junit
+junit_artifact_dir = junit
+coverage_artifact_dir = coverage
 
 [circleci_scraper]
 ;create a personal Circle CI token: https://circleci.com/docs/managing-api-tokens/

--- a/scripts/common/config.py
+++ b/scripts/common/config.py
@@ -20,7 +20,8 @@ class CommonConfig(BaseModel):
 
     test_result_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
     test_metadata_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
-    test_artifact_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
+    junit_artifact_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
+    coverage_artifact_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
 
 
 class InvalidConfigError(BaseError):
@@ -52,7 +53,8 @@ class BaseConfig:
             return CommonConfig(
                 test_result_dir=config_parser.get("common", "test_result_dir"),
                 test_metadata_dir=config_parser.get("common", "test_metadata_dir"),
-                test_artifact_dir=config_parser.get("common", "test_artifact_dir"),
+                junit_artifact_dir=config_parser.get("common", "junit_artifact_dir"),
+                coverage_artifact_dir=config_parser.get("common", "coverage_artifact_dir"),
             )
         except (NoSectionError, NoOptionError, ValidationError) as error:
             error_mapping: dict[type, str] = {

--- a/scripts/metric_reporter/base_reporter.py
+++ b/scripts/metric_reporter/base_reporter.py
@@ -51,7 +51,7 @@ class BaseReporter:
         try:
             report_path.parent.mkdir(parents=True, exist_ok=True)
             if not self.results:
-                self.logger.warning("No data to write to the CSV file.")
+                self.logger.warning(f"No data to write to {report_path}.")
                 return
 
             fieldnames: list[str] = list(self.results[0].dict_with_fieldnames().keys())

--- a/scripts/metric_reporter/config.py
+++ b/scripts/metric_reporter/config.py
@@ -21,7 +21,7 @@ class MetricReporterArgs(BaseModel):
     workflow: str
     test_suite: str
     metadata_path: Path
-    artifact_path: Path
+    junit_artifact_path: Path
     averages_csv_report_path: Path
     results_csv_report_path: Path
 
@@ -85,9 +85,9 @@ class Config(BaseConfig):
             for directory_path, directory_names, files in test_result_path.walk():
                 for directory_name in directory_names:
                     current_path = Path(directory_path) / directory_name
-                    artifact_path = current_path / self.common_config.test_artifact_dir
+                    junit_artifact_path = current_path / self.common_config.junit_artifact_dir
                     metadata_path = current_path / self.common_config.test_metadata_dir
-                    if artifact_path.exists() or metadata_path.exists():
+                    if junit_artifact_path.exists() or metadata_path.exists():
                         repository = self._normalize_name(Path(directory_path).parents[0].name)
                         test_suite = self._normalize_name(directory_name, "_")
                         test_metric_args = MetricReporterArgs(
@@ -95,7 +95,7 @@ class Config(BaseConfig):
                             workflow=directory_path.name,
                             test_suite=test_suite,
                             metadata_path=metadata_path,
-                            artifact_path=artifact_path,
+                            junit_artifact_path=junit_artifact_path,
                             averages_csv_report_path=(
                                 Path(self.metric_reporter_config.reports_dir)
                                 / f"{repository}_{test_suite}_averages.csv"

--- a/scripts/metric_reporter/main.py
+++ b/scripts/metric_reporter/main.py
@@ -44,13 +44,13 @@ def main(config_file: str = "config.ini") -> None:
                 circleci_parser = CircleCIJsonParser()
                 metadata_list = circleci_parser.parse(args.metadata_path)
 
-            artifact_list: list[JUnitXmlJobTestSuites] | None = None
-            if args.artifact_path.is_dir():
+            junit_artifact_list: list[JUnitXmlJobTestSuites] | None = None
+            if args.junit_artifact_path.is_dir():
                 junit_xml_parser = JUnitXmlParser()
-                artifact_list = junit_xml_parser.parse(args.artifact_path)
+                junit_artifact_list = junit_xml_parser.parse(args.junit_artifact_path)
 
             suite_reporter = SuiteReporter(
-                args.repository, args.workflow, args.test_suite, metadata_list, artifact_list
+                args.repository, args.workflow, args.test_suite, metadata_list, junit_artifact_list
             )
             suite_reporter.output_csv(args.results_csv_report_path)
 

--- a/tests/metric_reporter/test_averages_reporter.py
+++ b/tests/metric_reporter/test_averages_reporter.py
@@ -406,7 +406,7 @@ def test_averages_reporter_output_csv_with_empty_test_results(
     suite_results: Sequence[SuiteReporterResult] = []
     reporter = AveragesReporter(repository, workflow, test_suite, suite_results)
     report_path = test_data_directory / "fake_path.csv"
-    expected_log = "No data to write to the CSV file."
+    expected_log = f"No data to write to {report_path}."
 
     with caplog.at_level(logging.INFO):
         mock_open: MagicMock = mocker.mock_open()

--- a/tests/metric_reporter/test_data/xml_samples_nextest/1/nextest_success.xml
+++ b/tests/metric_reporter/test_data/xml_samples_nextest/1/nextest_success.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="autopush-unit-tests" tests="1" failures="0" errors="0" uuid="4ded7634-4e81-40ac-b3f9-060ffa546238" timestamp="2024-08-21T23:36:28.658+00:00" time="4.287">
+    <testsuite name="autoendpoint::bin/autoendpoint" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="error::tests::sentry_event_with_extras" classname="autoendpoint::bin/autoendpoint" timestamp="2024-08-21T23:36:36.475+00:00" time="4.287">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/metric_reporter/test_junit_xml_parser.py
+++ b/tests/metric_reporter/test_junit_xml_parser.py
@@ -227,6 +227,47 @@ EXPECTED_MOCHA = [
     )
 ]
 
+EXPECTED_NEXTEST = [
+    JUnitXmlJobTestSuites(
+        job=1,
+        test_suites=[
+            JUnitXmlTestSuites(
+                id=None,
+                name="autopush-unit-tests",
+                tests=1,
+                failures=0,
+                skipped=None,
+                errors=0,
+                time=4.287,
+                timestamp="2024-08-21T23:36:28.658+00:00",
+                test_suites=[
+                    JUnitXmlTestSuite(
+                        name="autoendpoint::bin/autoendpoint",
+                        timestamp=None,
+                        hostname=None,
+                        tests=1,
+                        failures=0,
+                        skipped=None,
+                        time=None,
+                        errors=0,
+                        test_cases=[
+                            JUnitXmlTestCase(
+                                name="error::tests::sentry_event_with_extras",
+                                classname="autoendpoint::bin/autoendpoint",
+                                time=4.287,
+                                properties=None,
+                                skipped=None,
+                                failure=None,
+                                system_out=None,
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+]
+
 EXPECTED_PLAYWRIGHT = [
     JUnitXmlJobTestSuites(
         job=1,
@@ -598,11 +639,12 @@ EXPECTED_TAP = [
     [
         ("xml_samples_jest", EXPECTED_JEST),
         ("xml_samples_mocha", EXPECTED_MOCHA),
+        ("xml_samples_nextest", EXPECTED_NEXTEST),
         ("xml_samples_playwright", EXPECTED_PLAYWRIGHT),
         ("xml_samples_pytest", EXPECTED_PYTEST),
         ("xml_samples_tap", EXPECTED_TAP),
     ],
-    ids=["jest", "mocha", "playwright", "pytest", "tap"],
+    ids=["jest", "mocha", "nextest", "playwright", "pytest", "tap"],
 )
 def test_parse(
     test_data_directory: Path,

--- a/tests/metric_reporter/test_suite_reporter.py
+++ b/tests/metric_reporter/test_suite_reporter.py
@@ -717,7 +717,7 @@ def test_suite_reporter_output_csv_with_empty_test_results(
     artifact_list: list[JUnitXmlJobTestSuites] | None = None
     reporter = SuiteReporter(repository, workflow, test_suite, metadata_list, artifact_list)
     report_path = test_data_directory / "fake_path.csv"
-    expected_log = "No data to write to the CSV file."
+    expected_log = f"No data to write to {report_path}"
 
     with caplog.at_level(logging.INFO):
         mock_open: MagicMock = mocker.mock_open()


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

* add support for scraping coverage reports
* add support for nextest XML Junit test results
* update deprecated pydantic methods to `model_dump()`
* update log message for when CSV reports can't be written

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Notes
* The updated raw data and reports are available in the [ETE team folder](https://drive.google.com/drive/folders/1N4YW97gEH6gmdlfDNtuGxUsdo2EKkCAi).

## Issues

Closes: #[ECTEEN-110](https://mozilla-hub.atlassian.net/browse/ECTEEN-110)



[ECTEEN-110]: https://mozilla-hub.atlassian.net/browse/ECTEEN-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ