### PR TITLE
fix(metric_reporter): filter for json suffix in metadata path

### DIFF
--- a/scripts/metric_reporter/parser/circleci_json_parser.py
+++ b/scripts/metric_reporter/parser/circleci_json_parser.py
@@ -65,7 +65,7 @@ class CircleCIJsonParser:
                          JSON data.
         """
         metadata_list: list[CircleCIJobTestMetadata] = []
-        metadata_file_paths: list[Path] = sorted(metadata_path.iterdir())
+        metadata_file_paths: list[Path] = sorted(metadata_path.glob("*.json"))
         for metadata_file_path in metadata_file_paths:
             self.logger.info(f"Parsing {metadata_file_path}")
             try:


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->
On Macs `.DS_Store` files can be mistaken for metadata files. This PR filters for the JSON format.

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes: # [ECTEEN-122](https://mozilla-hub.atlassian.net/browse/ECTEEN-122)



[ECTEEN-122]: https://mozilla-hub.atlassian.net/browse/ECTEEN-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ