### PR TITLE
fix(circleci_scraper): prevent data being scraped from running or cancelled jobs

### DIFF
--- a/scripts/circleci_scraper/scraper.py
+++ b/scripts/circleci_scraper/scraper.py
@@ -30,6 +30,8 @@ from scripts.common.config import CommonConfig
 from scripts.common.error import BaseError
 
 COVERAGE_FILE_REGEX = r".*cov.*\.json$"
+CANCELED_JOB_STATUS = "canceled"
+RUNNING_JOB_STATUS = "running"
 
 
 class CircleCIScraperError(BaseError):
@@ -181,6 +183,13 @@ class CircleCIScraper:
                         logging.warning(
                             f"Skipping data for workflow {workflow.id} because the job number is "
                             f"missing for {organization}>{repository}>{workflow.name}>{job.name}"
+                        )
+                        continue
+                    if job.status in [CANCELED_JOB_STATUS, RUNNING_JOB_STATUS]:
+                        logging.warning(
+                            f"Skipping data for workflow {workflow.id}, "
+                            f"{organization}>{repository}>{workflow.name}>{job.name} because the"
+                            " job is in progress or cancelled."
                         )
                         continue
                     self.export_test_metadata_by_job(organization, repository, workflow.name, job)

--- a/scripts/metric_reporter/reporter/suite_reporter.py
+++ b/scripts/metric_reporter/reporter/suite_reporter.py
@@ -21,6 +21,7 @@ SUCCESS_RESULTS = {"success", "system-out"}
 FAILURE_RESULT = "failure"
 SKIPPED_RESULT = "skipped"
 CANCELED_JOB_STATUS = "canceled"
+RUNNING_JOB_STATUS = "running"
 
 
 class Status(Enum):
@@ -225,8 +226,8 @@ class SuiteReporter(BaseReporter):
 
         return sorted_results
 
-    @staticmethod
     def _parse_metadata(
+        self,
         repository: str,
         workflow: str,
         test_suite: str,
@@ -235,6 +236,13 @@ class SuiteReporter(BaseReporter):
         results: dict[int, SuiteReporterResult] = {}
         for metadata in metadata_list:
             if not metadata.test_metadata or metadata.job.status == CANCELED_JOB_STATUS:
+                continue
+
+            if metadata.job.status == RUNNING_JOB_STATUS:
+                self.logger.warning(
+                    f"Files from job {repository}/{workflow}/{test_suite}/{metadata.job.job_number}"
+                    " are incomplete. Please delete them and re-scrape."
+                )
                 continue
 
             started_at = datetime.strptime(metadata.job.started_at, DATETIME_FORMAT)


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

- prevents data being scraped for running or cancelled jobs in the CircleCI Scraper script
- outputs a warning should 'running' test data be detected in the Test Metric Reporter script

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes: # (ECTEEN-144)[https://mozilla-hub.atlassian.net/browse/ECTEEN-144]

