### PR TITLE
chore(cron): pin testrail workflow to Python 3.12

### DIFF
--- a/.github/workflows/production_testrail_metrics_weekly.yml
+++ b/.github/workflows/production_testrail_metrics_weekly.yml
@@ -16,6 +16,8 @@ jobs:
           repository: mozilla-mobile/testops-dashboard
       - name: Setup python
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Authenticate to Google
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Description

Adds explicit Python version for replicability between runs, in sync with the env setup in other GH Actions here, instead of defaulting to what's in the runner image binary path.

Resolves warnings/annotations attached to runs, NB: the runner defaults will change soon when migrating the ubuntu-latest versions, so it's more stable to be on an explicit Python env now.

- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] ~AI tools were used in generating this pull request~

