### PR TITLE
refactor(circleci scraper): remove support for downloading circleci test metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests with coverage
+name: Check and Test
 
 on:
   pull_request:

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,6 +1,5 @@
 [common]
 test_result_dir = raw_data
-test_metadata_dir = circle_ci
 junit_artifact_dir = junit
 coverage_artifact_dir = coverage
 

--- a/scripts/circleci_scraper/client.py
+++ b/scripts/circleci_scraper/client.py
@@ -92,24 +92,6 @@ class JobGroup(BaseModel):
     items: list[Job]
 
 
-class TestMetadata(BaseModel):
-    """CircleCI TestMetadata."""
-
-    classname: str
-    name: str
-    result: str
-    message: str
-    run_time: float
-    source: str
-
-
-class TestMetadataGroup(BaseModel):
-    """CircleCI TestMetadata collection."""
-
-    next_page_token: str | None = None
-    items: list[TestMetadata]
-
-
 class Artifact(BaseModel):
     """CircleCI Artifact."""
 
@@ -228,33 +210,6 @@ class CircleCIClient:
             f"{(f'?page-token={next_page_token}' if next_page_token else '')}"
         )
         return self._make_request(endpoint, JobGroup)
-
-    def get_test_metadata(
-        self,
-        organization: str,
-        repository: str,
-        job_number: str,
-        next_page_token: str | None = None,
-    ) -> TestMetadataGroup:
-        """Retrieve test metadata for the specified job.
-
-        Args:
-            organization (str): The organization name.
-            repository (str): The repository name.
-            job_number (str): The job number.
-            next_page_token (str | None): The token for the next page of results. Defaults to None.
-
-        Returns:
-            TestMetadataGroup: The response from the API.
-
-        Raises:
-            CircleCIClientError: If the request to the API fails.
-        """
-        endpoint = (
-            f"project/{self._vcs_slug}/{organization}/{repository}/{job_number}/tests"
-            f"{(f'?page-token={next_page_token}' if next_page_token else '')}"
-        )
-        return self._make_request(endpoint, TestMetadataGroup)
 
     def get_job_artifacts(
         self,

--- a/scripts/circleci_scraper/main.py
+++ b/scripts/circleci_scraper/main.py
@@ -32,7 +32,7 @@ def main(config_file: str = "config.ini") -> None:
         )
         client = CircleCIClient(config.circleci_scraper_config)
         scraper = CircleCIScraper(config.common_config, client)
-        scraper.export_test_metadata_and_artifacts(
+        scraper.export_test_artifacts(
             config.circleci_scraper_config.pipelines, config.circleci_scraper_config.date_limit
         )
         logger.info("Scraping complete")

--- a/scripts/common/config.py
+++ b/scripts/common/config.py
@@ -19,7 +19,6 @@ class CommonConfig(BaseModel):
     """Configuration model for common settings."""
 
     test_result_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
-    test_metadata_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
     junit_artifact_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
     coverage_artifact_dir: str = Field(..., pattern=DIRECTORY_PATTERN)
 
@@ -52,7 +51,6 @@ class BaseConfig:
         try:
             return CommonConfig(
                 test_result_dir=config_parser.get("common", "test_result_dir"),
-                test_metadata_dir=config_parser.get("common", "test_metadata_dir"),
                 junit_artifact_dir=config_parser.get("common", "junit_artifact_dir"),
                 coverage_artifact_dir=config_parser.get("common", "coverage_artifact_dir"),
             )


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

This PR update the CircleCI Scraper script to no longer download CircleCI JSON files. The script will continue to download JUnit XML and Coverage JSON files. This change is part of a larger effort to be CI agnostric

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes: # [ECTEEN-170](https://mozilla-hub.atlassian.net/browse/ECTEEN-170)



[ECTEEN-170]: https://mozilla-hub.atlassian.net/browse/ECTEEN-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ