### PR TITLE
docs(common): update setup instructions and procedures to use GCP cloud storage instead of team drive

### DIFF
--- a/docs/developer-guides/developer_setup.md
+++ b/docs/developer-guides/developer_setup.md
@@ -38,10 +38,11 @@ local `config.ini` file:
 
 ## 5. Copy the latest raw data locally
 
-By default, CircleCI has a retention policy of 30 days for artifacts and 90 days for uploaded test
-results; However, we have over a years worth of data gathered for some projects. In order to produce
-reports with full trend data and reduce scraping time, copy the latest `raw_data` from the
-[ETE team folder][ETE Drive] to the root directory of the `ecosystem-test-scripts` project.
+By default, CircleCI has a retention policy of 30 days for artifacts; However, we have over a years
+worth of data gathered for some projects. In order to produce reports with full trend data and
+reduce scraping time, copy the latest `raw_data` from the
+[ecosystem-test-eng-metrics GCP Cloud Bucket][GCP Cloud Bucket] to the root directory of the
+`ecosystem-test-scripts` project.
 
 ## 6. Set up the python virtual environment
 
@@ -66,9 +67,9 @@ make help
 [CircleCI Create API Token]: https://circleci.com/docs/managing-api-tokens/#creating-a-personal-api-token
 [Community Participation Guidelines]: https://github.com/mozilla/ecosystem-test-scripts/blob/main/CODE_OF_CONDUCT.md
 [Contributing Guidelines]: https://github.com/mozilla/ecosystem-test-scripts/blob/main/CONTRIBUTING.md
-[ETE Drive]: https://drive.google.com/drive/folders/1N4YW97gEH6gmdlfDNtuGxUsdo2EKkCAi
 [ETE GCP Project]: https://console.cloud.google.com/welcome?project=ecosystem-test-eng
 [ETE GCP Service Accounts]: https://console.cloud.google.com/iam-admin/serviceaccounts?project=ecosystem-test-eng
+[GCP Cloud Bucket]: https://console.cloud.google.com/storage/browser/ecosystem-test-eng-metrics
 [Github Cloning A Repository]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
 [Mozilla Github]: https://github.com/mozilla/ecosystem-test-scripts/
 [Poetry]: https://python-poetry.org/docs/#installing-with-pipx

--- a/docs/reference-guides/metric_update_procedure.md
+++ b/docs/reference-guides/metric_update_procedure.md
@@ -16,7 +16,8 @@ Before updating the test metrics, ensure that:
 - You have the latest raw data in the ecosystem-test-scripts root directory.
   - The raw data should be found in the `test_result_dir` specified in the config.ini file and is
     typically named `raw_data`.
-  - The latest raw data is available in the [ETE team folder][ETE Drive]
+  - The latest raw data is available in the
+    [ecosystem-test-eng-metrics GCP Cloud Bucket][GCP Cloud Bucket]
 
 ## 1. Scrape for New Raw Test Data
 
@@ -49,11 +50,11 @@ _**Notes**:_
   tests.
 
 
-## 3. Backup the latest `test_result_dir` to the ETE team folder
+## 3. Backup the latest `test_result_dir` to the GCP Cloud Bucket
 
-Compress the contents of the `test_result_dir`, typically called 'raw_data,' and replace the file
-located in the [ETE team folder][ETE Drive].
+Upload the new contents of the `test_result_dir`, typically called 'raw_data', to the
+[ecosystem-test-eng-metrics GCP Cloud Bucket][GCP Cloud Bucket].
 
 [Developer Setup Guide]: ../developer-guides/developer_setup.md
-[ETE Drive]: https://drive.google.com/drive/folders/1N4YW97gEH6gmdlfDNtuGxUsdo2EKkCAi
 [ETE Looker Dashboards]: https://mozilla.cloud.looker.com/boards/140
+[GCP Cloud Bucket]: https://console.cloud.google.com/storage/browser/ecosystem-test-eng-metrics

--- a/docs/reference-guides/project_onboarding_procedure.md
+++ b/docs/reference-guides/project_onboarding_procedure.md
@@ -6,8 +6,8 @@ Below are step-by-step instructions on how to onboard a project to report test m
 
 To report test metrics for a project, ensure the following requirements are met:
 
-- The project uses [CircleCI][CircleCI] for test execution, and members of the ETE team have access to the
-  CircleCI pipelines.
+- The project uses [CircleCI][CircleCI] for test execution, and members of the ETE team have access
+  to the CircleCI pipelines.
 - Testing and coverage results are stored as artifacts in CircleCI jobs:
   - Test results must be in JUnit format.
   - Coverage results must be in JSON format.
@@ -26,8 +26,8 @@ To report test metrics for a project, ensure the following requirements are met:
   ```shell
   make run_circleci_scraper
   ```
-- Once scraping is complete, compress the contents of `test_result_dir`, and replace the
-  corresponding file in the [ETE team folder][ETE Drive].
+- Once scraping is complete, upload the new contents of the `test_result_dir` to the
+  [ecosystem-test-eng-metrics GCP Cloud Bucket][GCP Cloud Bucket].
 
 ## 2. Create and Populate Tables in the ETE BigQuery Dataset
 
@@ -65,10 +65,10 @@ To report test metrics for a project, ensure the following requirements are met:
 
 [BigQuery Documentation]: https://cloud.google.com/bigquery/docs/tables#create-table
 [CircleCI]: https://app.circleci.com/home
-[ETE Drive]: https://drive.google.com/drive/folders/1N4YW97gEH6gmdlfDNtuGxUsdo2EKkCAi
 [ETE BigQuery]: https://console.cloud.google.com/bigquery?cloudshell=false&project=ecosystem-test-eng
 [ETE Looker]: https://mozilla.cloud.looker.com/projects/ecosystem-test-eng
 [ETE Looker Dashboards]: https://mozilla.cloud.looker.com/boards/140
+[GCP Cloud Bucket]: https://console.cloud.google.com/storage/browser/ecosystem-test-eng-metrics
 [Github ETE Looker]: https://github.com/mozilla/looker-ecosystem-test-eng
 [Metric Interpretation Guide]: ../reference-guides/metric_interpretation_guide.md
 [Mozilla Confluence]: https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27920436/Looker

--- a/scripts/circleci_scraper/scraper.py
+++ b/scripts/circleci_scraper/scraper.py
@@ -22,12 +22,8 @@ from client import (
     Artifact,
     Workflow,
 )
-from scripts.circleci_scraper.config import (
-    CircleCIScraperJobConfig,
-    CircleCIScraperPipelineConfig,
-)
+from scripts.circleci_scraper.config import CircleCIScraperPipelineConfig
 from scripts.common.config import CommonConfig
-from scripts.common.constants import DATETIME_FORMAT, DATETIME_MILLISECOND_FORMAT
 from scripts.common.error import BaseError
 
 COVERAGE_FILE_REGEX = r".*cov.*\.json$"
@@ -107,7 +103,7 @@ class CircleCIScraper:
                     continue
                 # Filter for date limit
                 created_at_datetime = datetime.strptime(
-                    pipeline.created_at, DATETIME_MILLISECOND_FORMAT
+                    pipeline.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
                 ).replace(tzinfo=timezone.utc)
                 if date_limit and created_at_datetime < date_limit:
                     return
@@ -126,7 +122,7 @@ class CircleCIScraper:
         pipeline_id: str,
         organization: str,
         repository: str,
-        workflow_configs: dict[str, list[CircleCIScraperJobConfig]],
+        workflow_configs: dict[str, list[str]],
     ) -> None:
         """Export test artifacts for a specific pipeline ID.
 
@@ -134,8 +130,7 @@ class CircleCIScraper:
             pipeline_id (str): The pipeline ID.
             organization (str): The organization name.
             repository (str): The repository name.
-            workflow_configs (dict[str, list[CircleCIScraperJobConfig]]): The workflow
-                                                                          configurations.
+            workflow_configs (dict[str, list[str]]): The workflow configurations.
 
         Raises:
             CircleCIClientError: If there is an error in the CircleCI API request.
@@ -146,9 +141,9 @@ class CircleCIScraper:
             workflows: WorkflowGroup = self._client.get_workflows(pipeline_id, next_page_token)
             for workflow in workflows.items:
                 if workflow.name in workflow_configs:
-                    job_configs: list[CircleCIScraperJobConfig] = workflow_configs[workflow.name]
+                    job_names = workflow_configs[workflow.name]
                     self.export_test_artifacts_workflow_id(
-                        organization, repository, workflow, job_configs
+                        organization, repository, workflow, job_names
                     )
             next_page_token = workflows.next_page_token
             if not next_page_token:
@@ -159,7 +154,7 @@ class CircleCIScraper:
         organization: str,
         repository: str,
         workflow: Workflow,
-        job_configs: list[CircleCIScraperJobConfig],
+        job_names: list[str],
     ) -> None:
         """Export test artifacts for a specific workflow ID.
 
@@ -167,7 +162,7 @@ class CircleCIScraper:
             organization (str): The organization name.
             repository (str): The repository name.
             workflow (Workflow): The workflow.
-            job_configs (list[CircleCIScraperJobConfig]): A list of job configs.
+            job_names (list[str]): A list of job names.
 
         Raises:
             CircleCIClientError: If there is an error in the CircleCI API request.
@@ -177,9 +172,7 @@ class CircleCIScraper:
         while True:
             jobs: JobGroup = self._client.get_jobs(workflow.id, next_page_token)
             for job in jobs.items:
-                if job_config := next(
-                    (config for config in job_configs if job.name == config.job_name), None
-                ):
+                if job.name in job_names:
                     if not job.job_number:
                         # This happens when workflows are cancelled before a number is assigned
                         # to the test job
@@ -195,9 +188,7 @@ class CircleCIScraper:
                             " job is in progress or cancelled."
                         )
                         continue
-                    self.export_test_artifacts_by_job(
-                        organization, repository, workflow.name, job_config.test_suite, job
-                    )
+                    self.export_test_artifacts_by_job(organization, repository, workflow.name, job)
             next_page_token = jobs.next_page_token
             if not next_page_token:
                 break
@@ -207,7 +198,6 @@ class CircleCIScraper:
         organization: str,
         repository: str,
         workflow_name: str,
-        test_suite: str,
         job: Job,
     ) -> None:
         """Export test artifacts for a specific job.
@@ -216,7 +206,6 @@ class CircleCIScraper:
             organization (str): The organization name.
             repository (str): The repository name.
             workflow_name (str): The workflow name.
-            test_suite (str): The test suite name.
             job (Job): The job details.
 
         Raises:
@@ -243,21 +232,11 @@ class CircleCIScraper:
                 break
         if junit_artifacts:
             self.export_artifacts(
-                repository,
-                workflow_name,
-                self._junit_artifact_dir,
-                test_suite,
-                job,
-                junit_artifacts,
+                repository, workflow_name, self._junit_artifact_dir, job, junit_artifacts
             )
         if coverage_artifacts:
             self.export_artifacts(
-                repository,
-                workflow_name,
-                self._coverage_artifact_dir,
-                test_suite,
-                job,
-                coverage_artifacts,
+                repository, workflow_name, self._coverage_artifact_dir, job, coverage_artifacts
             )
 
     def export_artifacts(
@@ -265,7 +244,6 @@ class CircleCIScraper:
         repository: str,
         workflow_name: str,
         artifact_directory: str,
-        test_suite: str,
         job: Job,
         artifacts: list[Artifact],
     ):
@@ -275,7 +253,6 @@ class CircleCIScraper:
             repository (str): The repository name.
             workflow_name (str): The workflow name.
             artifact_directory (str): The destination directory name for artifacts.
-            test_suite (str): The test suite name.
             job (Job): The job details.
             artifacts (list[Artifact]): The list of artifacts.
 
@@ -283,30 +260,22 @@ class CircleCIScraper:
             CircleCIClientError: If there is an error in the CircleCI API request.
             CircleCIScraperError: If there is an error in downloading the artifacts.
         """
-        destination_path = Path(self._test_result_dir) / repository / artifact_directory
-        destination_path.mkdir(parents=True, exist_ok=True)
+        artifact_path = (
+            Path(self._test_result_dir)
+            / repository
+            / workflow_name
+            / job.name
+            / artifact_directory
+            / f"{str(job.job_number)}_{job.started_at}"
+        )
+        if artifact_path.exists():
+            self.logger.info(f"{artifact_path} already exists, skipping download(s).")
+            return
+
+        artifact_path.mkdir(parents=True)
         for index, artifact in enumerate(artifacts):
-            job_datetime = datetime.strptime(job.started_at, DATETIME_FORMAT).replace(
-                tzinfo=timezone.utc
-            )
-            epoch = int(job_datetime.timestamp())
-            artifact_path = Path(artifact.path)
-            # FxA doesn't guarantee unique names for their test files, so concatenating the parent
-            # directory is a necessary evil atm
-            destination_file_name = (
-                f"{str(job.job_number)}__"
-                f"{epoch}__"
-                f"{repository}__"
-                f"{workflow_name}__"
-                f"{test_suite}__"
-                f"{f'{artifact_path.parent.name.replace("_", "-")}-' if artifact_path.parent.name else ''}"
-                f"{artifact_path.name.replace("_", "-")}"
-            )
-            destination_file_path: Path = destination_path / destination_file_name
-            if destination_file_path.exists():
-                self.logger.info(f"{destination_file_path} already exists, skipping download.")
-            else:
-                self.download_artifact(destination_file_path, artifact.url)
+            file_path: Path = artifact_path / f"{index}-{Path(artifact.path).name}"
+            self.download_artifact(file_path, artifact.url)
 
     def download_artifact(self, file_name: Path, url: str) -> None:
         """Download an artifact from the specified URL.


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

- Data is now stored in [ecosystem-test-eng-metrics cloud bucket](https://console.cloud.google.com/storage/browser/ecosystem-test-eng-metrics)

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes: # [ECTEEN-173](https://mozilla-hub.atlassian.net/browse/ECTEEN-173)



[ECTEEN-173]: https://mozilla-hub.atlassian.net/browse/ECTEEN-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ