### PR TITLE
feat(metric_reporter): interpret errors as test failures for test metrics

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -20,23 +20,23 @@ pipelines = [
             },
             {
               "job_name": "Integration Test - Frontends (nightly)",
-              "test_suite": "integration-frontends"
+              "test_suite": "frontends-integration"
             },
             {
               "job_name": "Integration Test - Libraries (nightly)",
-              "test_suite": "integration-libraries"
+              "test_suite": "libraries-integration"
             },
             {
               "job_name": "Integration Test - Servers (nightly)",
-              "test_suite": "integration-servers"
+              "test_suite": "servers-integration"
             },
             {
               "job_name": "Integration Test - Servers - Auth (nightly)",
-              "test_suite": "integration-servers-auth"
+              "test_suite": "servers-auth-integration"
             },
             {
               "job_name": "Integration Test - Servers - Auth V2 (nightly)",
-              "test_suite": "integration-servers-auth-v2"
+              "test_suite": "servers-auth-v2-integration"
             },
             {
               "job_name": "Functional Tests - Playwright (nightly)",
@@ -58,23 +58,23 @@ pipelines = [
             },
             {
               "job_name": "Integration Test - Frontends",
-              "test_suite": "integration-frontends"
+              "test_suite": "frontends-integration"
             },
             {
               "job_name": "Integration Test - Libraries",
-              "test_suite": "integration-libraries"
+              "test_suite": "libraries-integration"
             },
             {
               "job_name": "Integration Test - Servers",
-              "test_suite": "integration-servers"
+              "test_suite": "servers-integration"
             },
             {
               "job_name": "Integration Test - Servers - Auth",
-              "test_suite": "integration-servers-auth"
+              "test_suite": "servers-auth-integration"
             },
             {
               "job_name": "Integration Test - Servers - Auth V2",
-              "test_suite": "integration-servers-auth-v2"
+              "test_suite": "servers-auth-v2-integration"
             },
             {
               "job_name": "Functional Tests - Playwright",

--- a/scripts/metric_reporter/reporter/suite_reporter.py
+++ b/scripts/metric_reporter/reporter/suite_reporter.py
@@ -327,7 +327,7 @@ class SuiteReporter(BaseReporter):
             case JestJUnitXmlTestSuites() | NextestJUnitXmlTestSuites():
                 metrics.time = suites.time
                 metrics.tests = suites.tests
-                metrics.failure = suites.failures
+                metrics.failure = suites.failures + suites.errors
                 metrics.skipped = sum(suite.skipped for suite in suites.test_suites)
             case MochaJUnitXmlTestSuites():
                 metrics.time = suites.time
@@ -343,7 +343,7 @@ class SuiteReporter(BaseReporter):
             case PlaywrightJUnitXmlTestSuites():
                 metrics.time = suites.time
                 metrics.tests = suites.tests
-                metrics.failure = suites.failures
+                metrics.failure = suites.failures + suites.errors
                 metrics.skipped = suites.skipped
                 metrics.fixme = sum(
                     1
@@ -363,11 +363,16 @@ class SuiteReporter(BaseReporter):
             case PytestJUnitXmlTestSuites():
                 metrics.time = sum(suite.time for suite in suites.test_suites)
                 metrics.tests = sum(suite.tests for suite in suites.test_suites)
-                metrics.failure = sum(suite.failures for suite in suites.test_suites)
+                metrics.failure = sum(
+                    suite.failures + suite.errors for suite in suites.test_suites
+                )
                 metrics.skipped = sum(suite.skipped for suite in suites.test_suites)
             case TapJUnitXmlTestSuites():
                 metrics.tests = sum(suite.tests for suite in suites.test_suites)
-                metrics.failure = sum(suite.failures for suite in suites.test_suites)
+                # With Tap it's possible for errors to be omitted
+                metrics.failure = sum(
+                    suite.failures + (suite.errors or 0) for suite in suites.test_suites
+                )
         return metrics
 
     def _parse_results(

--- a/tests/metric_reporter/test_data/xml_samples_pytest/1__1720019124__repo__main__suite__error.xml
+++ b/tests/metric_reporter/test_data/xml_samples_pytest/1__1720019124__repo__main__suite__error.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1" time="2.368"
+               timestamp="2024-07-03T15:05:24.621274" hostname="ip-10-0-191-153">
+        <testcase classname="" name="" time="0.000">
+            <error message="collection failure">
+                /opt/circleci/.pyenv/versions/3.12.1/lib/python3.12/importlib/__init__.py:90: in
+                import_module
+                return _bootstrap._gcd_import(name[level:], package, level)
+                &lt;frozen importlib._bootstrap&gt;:1387: in _gcd_import
+                ???
+                &lt;frozen importlib._bootstrap&gt;:1360: in _find_and_load
+                ???
+                &lt;frozen importlib._bootstrap&gt;:1331: in _find_and_load_unlocked
+                ???
+                &lt;frozen importlib._bootstrap&gt;:935: in _load_unlocked
+                ???
+                ../.cache/pypoetry/virtualenvs/merino-py-3aSsmiER-py3.12/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:186:
+                in exec_module
+                exec(co, module.__dict__)
+                tests/integration/api/conftest.py:26: in &lt;module&gt;
+                from merino.main import app
+                merino/main.py:15: in &lt;module&gt;
+                from merino.providers import suggest, manifest
+                merino/providers/suggest/__init__.py:10: in &lt;module&gt;
+                from merino.providers.suggest.manager import load_providers
+                merino/providers/suggest/manager.py:22: in &lt;module&gt;
+                from merino.providers.suggest.top_picks.backends.top_picks import TopPicksBackend
+                merino/providers/suggest/top_picks/backends/top_picks.py:13: in &lt;module&gt;
+                from merino.providers.suggest.top_picks.backends.filemanager import (
+                merino/providers/suggest/top_picks/backends/filemanager.py:10: in &lt;module&gt;
+                from merino.utils.gcs.gcp_uploader import GcsUploader
+                E ModuleNotFoundError: No module named 'merino.utils.gcs.gcp_uploader'
+            </error>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/metric_reporter/test_data/xml_samples_pytest/1__1720019124__repo__main__suite__skipped.xml
+++ b/tests/metric_reporter/test_data/xml_samples_pytest/1__1720019124__repo__main__suite__skipped.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-    <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="1" time="0.000" timestamp="2024-08-06T09:17:36.201378" hostname="ip-10-0-175-52">
+    <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="1" time="0.000" timestamp="2024-07-03T15:05:24.201378" hostname="ip-10-0-175-52">
         <testcase classname="tests.unit.providers.weather.test_provider" name="test_enabled_by_default" time="0.000">
             <skipped type="pytest.skip" message="see DISCO-5555">
                 /merino-py/tests/unit/providers/weather/test_provider.py:59:

--- a/tests/metric_reporter/test_junit_xml_parser.py
+++ b/tests/metric_reporter/test_junit_xml_parser.py
@@ -478,6 +478,23 @@ EXPECTED_PYTEST = [
                         test_suites=[
                             PytestJUnitXmlTestSuite(
                                 name="pytest",
+                                timestamp="2024-07-03T15:05:24.621274",
+                                hostname="ip-10-0-191-153",
+                                tests=1,
+                                failures=0,
+                                skipped=0,
+                                time=2.368,
+                                errors=1,
+                                test_cases=[
+                                    PytestJUnitXmlTestCase(name="", classname="", time=0.0)
+                                ],
+                            )
+                        ]
+                    ),
+                    PytestJUnitXmlTestSuites(
+                        test_suites=[
+                            PytestJUnitXmlTestSuite(
+                                name="pytest",
                                 timestamp="2024-07-03T15:05:24.279183",
                                 hostname="ip-10-0-175-52",
                                 tests=1,
@@ -505,7 +522,7 @@ EXPECTED_PYTEST = [
                         test_suites=[
                             PytestJUnitXmlTestSuite(
                                 name="pytest",
-                                timestamp="2024-08-06T09:17:36.201378",
+                                timestamp="2024-07-03T15:05:24.201378",
                                 hostname="ip-10-0-175-52",
                                 tests=1,
                                 failures=0,


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

An error occurred on January 29th 2025 with Merino integration tests, the first example we have of this property in use. With this example we can now improve test metric interpretation to handle errors as failures for more accurate success metrics. Note that Mocha doesn't support 'error' as a property.

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Closes: # [ECTEEN-228](https://mozilla-hub.atlassian.net/browse/ECTEEN-228)



[ECTEEN-228]: https://mozilla-hub.atlassian.net/browse/ECTEEN-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ