### PR TITLE
chore(docs): bump mdbook to v0.4.44

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.40
+      MDBOOK_VERSION: 0.4.44
     steps:
       - uses: actions/checkout@v4
       - name: Install mdBook


### PR DESCRIPTION
## Description

Updates mdbook version used in CI for docs deployment from 0.4.40 (5/24) to 0.4.44 (1/25)

The main changes are fixes to nonJS rendering, sidebar performance etc., should have no other impact. (Preview: https://janbrasna.github.io/ecosystem-test-scripts/, [buildlog](https://github.com/janbrasna/ecosystem-test-scripts/actions/runs/13372485203/job/37343999604) …)

https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0444
https://github.com/rust-lang/mdBook/compare/v0.4.40...v0.4.44

- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- ~AI tools were used in generating this pull request~