### PR TITLE
chore(circleci_scraper): remove autopush-rs from scraping since the CI now pushes files

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -96,23 +96,6 @@ pipelines = [
             }
           ]
         }
-      },
-      {
-        "organization": "mozilla-services",
-        "repository": "autopush-rs",
-        "branches": ["master"],
-        "workflows": {
-          "build-test-deploy": [
-            {
-              "job_name": "Rust Unit Tests",
-              "test_suite": "unit"
-            },
-            {
-              "job_name": "Integration Tests",
-              "test_suite": "integration"
-            }
-          ]
-        }
       }
     ]
 ;(optional) Get data starting from x days past from now (default: all available data)


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

Remove autopush-rs from scraping.

**ONLY MERGE AFTER https://github.com/mozilla-services/autopush-rs/pull/843**

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Relates To: # [SYNC-4574](https://mozilla-hub.atlassian.net/browse/SYNC-4574)



[SYNC-4574]: https://mozilla-hub.atlassian.net/browse/SYNC-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ