### PR TITLE
chore(circleci_scraper): remove merino-py from scraping since the CI now pushes files

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -113,22 +113,6 @@ pipelines = [
             }
           ]
         }
-      },
-      {
-        "organization": "mozilla-services",
-        "repository": "merino-py",
-        "workflows": {
-          "main-workflow": [
-            {
-              "job_name": "unit-tests",
-              "test_suite": "unit"
-            },
-            {
-              "job_name": "integration-tests",
-              "test_suite": "integration"
-            }
-          ]
-        }
       }
     ]
 ;(optional) Get data starting from x days past from now (default: all available data)


### PR DESCRIPTION
## Description
<!-- Detail the purpose and impact of this PR, along with any other relevant information including: 
change highlights, screenshots, test instructions, etc .... -->

Remove merino-py from scraping.

**ONLY MERGE AFTER** https://github.com/mozilla-services/merino-py/pull/798

<!-- Check all that apply -->
- [x] This PR conforms to the [Contribution Guidelines](/CONTRIBUTING)
- [ ] AI tools were used in generating this pull request

## Issues

Relates To: [DISCO-3134](https://mozilla-hub.atlassian.net/browse/DISCO-3134)



[DISCO-3134]: https://mozilla-hub.atlassian.net/browse/DISCO-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ